### PR TITLE
fix(builder-main): Reactivity improvement

### DIFF
--- a/src/components/Builder/BuilderMain.vue
+++ b/src/components/Builder/BuilderMain.vue
@@ -202,7 +202,7 @@ const updateBlockValue = ({ id, value }) => {
 
 const updateElementValue = (index, newValue) => {
 	const updatedElements = [...props.elements];
-	updatedElements.splice(index, 1, {
+	props.elements.splice(index, 1, {
 		...props.elements[index],
 		value: newValue,
 	});


### PR DESCRIPTION
This commit ensures a direct update of `props.elements` for better reactivity and resolves the problem of not updating the image value.